### PR TITLE
Update MongoDB Connection Configuration in application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,3 @@
 spring.application.name=risksrv3
 server.port=8082
-spring.data.mongodb.host=localhost
-spring.data.mongodb.port=27017
-spring.data.mongodb.database=riskdata
+spring.data.mongodb.uri=${MONGODB_URI:mongodb://host.docker.internal:27018/riskdata}


### PR DESCRIPTION
This pull request includes a change to the `src/main/resources/application.properties` file to update the MongoDB connection configuration.

Configuration update:

* Changed the MongoDB connection properties to use a URI with a default value of `mongodb://host.docker.internal:27018/riskdata` instead of separate host and port properties.