### PR TITLE
CI workflow for building and publishing Docker images

### DIFF
--- a/.github/workflows/actus-riskservice-ci.yml
+++ b/.github/workflows/actus-riskservice-ci.yml
@@ -1,0 +1,56 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    tags:
+      - "v**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-actus-riskservice-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+       
+      - name: Checkout actus-core repository
+        uses: actions/checkout@v3
+        with:
+            repository: ${{ github.repository_owner }}/actus-core
+          ref: ${{ github.ref_name }}
+          path: actus-core
+          fetch-depth: 1
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ vars.DOCKER_USERNAME }}/actus-riskservice:${{ github.ref_name }}
+            ${{ vars.DOCKER_USERNAME }}/actus-riskservice:latest
+          platforms: linux/amd64,linux/arm64
+
+  publish:
+    needs: [build-actus-riskservice-images]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Docker image
+        run: echo "Docker image has been built and pushed successfully"
+      

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM eclipse-temurin:17-jdk-jammy
+
+# Install dependencies: bash, curl, unzip, Maven, and Gradle
+ENV GRADLE_VERSION=8.4 \
+    MAVEN_VERSION=3.9.4 \
+    GRADLE_HOME=/opt/gradle \
+    PATH=/opt/gradle/bin:/opt/maven/bin:$PATH \
+    MAVEN_HOME=/opt/maven
+
+RUN apt-get update && \
+    apt-get install -y bash curl unzip && \
+    # Install Maven
+    curl -sLO https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.zip && \
+    unzip apache-maven-${MAVEN_VERSION}-bin.zip && \
+    mv apache-maven-${MAVEN_VERSION} /opt/maven && \
+    rm apache-maven-${MAVEN_VERSION}-bin.zip && \
+    # Install Gradle
+    curl -sLO https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
+    unzip gradle-${GRADLE_VERSION}-bin.zip && \
+    mkdir /opt/gradle && \
+    mv gradle-${GRADLE_VERSION}/* /opt/gradle/ && \
+    rm gradle-${GRADLE_VERSION}-bin.zip && \
+    # Clean up
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Step 1: Copy and build the actus-core project using Maven
+COPY actus-core /app/actus-core
+WORKDIR /app/actus-core
+RUN mvn clean install
+RUN rm -rf src
+
+# Step 2: Copy and build the actus-riskservice project using Gradle
+COPY . /app/actus-riskservice
+WORKDIR /app/actus-riskservice
+RUN gradle clean
+
+# Expose port 8082
+EXPOSE 8082
+
+# Default command
+CMD ["gradle", "bootRun"]

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=risksrv3
 server.port=8082
-spring.data.mongodb.host=localhost
+spring.data.mongodb.host=host.docker.internal
 spring.data.mongodb.port=27017
 spring.data.mongodb.database=riskdata


### PR DESCRIPTION
This pull request implements a CI workflow for building and publishing Docker images, and updates the Dockerfile to include necessary dependencies and build steps for the `actus-riskservice` and `actus-core` projects.

### CI Workflow:
* [`.github/workflows/actus-riskservice-ci.yml`](diffhunk://#diff-bfcfa59a09804aea5164ae0918368f3d0fa92f2cb61745e472b9be73b9060913R1-R56): Added a new GitHub Actions workflow to build and publish Docker images on tag pushes. This includes steps for checking out code, setting up QEMU and Docker Buildx, logging into Docker Hub, and building and pushing the Docker image.

### Dockerfile:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R45): Updated to use the `eclipse-temurin:17-jdk-jammy` base image. Added installation steps for dependencies such as Maven and Gradle. Defined build steps for `actus-core` using Maven and `actus-riskservice` using Gradle. Exposed port 8082 and set the default command to `gradle bootRun`.